### PR TITLE
Define is_integral function and use it in typechecking array access

### DIFF
--- a/lib/typecheck.ml
+++ b/lib/typecheck.ml
@@ -43,6 +43,7 @@ let is_integral (_, typ, _) =
       Basetype "uint32_t";
       Basetype "uint16_t";
       Basetype "uint8_t";
+      Basetype "char";
     ]
   in
   List.mem typ nums
@@ -53,6 +54,7 @@ let is_numerical (_, typ, _) =
     [
       Basetype "int";
       Basetype "float";
+      Basetype "double";
       Basetype "size_t";
       Basetype "int64_t";
       Basetype "int32_t";
@@ -62,13 +64,17 @@ let is_numerical (_, typ, _) =
       Basetype "uint32_t";
       Basetype "uint16_t";
       Basetype "uint8_t";
+      Basetype "char";
     ]
   in
   List.mem typ nums
 
-(** provides an integer ranking of numerical types: higher values are least
+(* TODO: This ranking cannot be done with a total order, signed and unsigned are not comparable *)
+
+(** provides an integer ranking of numerical types: higher values are most
     general types *)
 let numerical_rank : perktype -> int = function
+  | _, Basetype "double", _ -> 12
   | _, Basetype "float", _ -> 11
   | _, Basetype "int64_t", _ -> 10
   | _, Basetype "size_t", _ -> 9
@@ -79,6 +85,8 @@ let numerical_rank : perktype -> int = function
   | _, Basetype "int16_t", _ -> 4
   | _, Basetype "uint16_t", _ -> 3
   | _, Basetype "int8_t", _ -> 2
+  | _, Basetype "char", _ ->
+      2 (* char's signedness is implementation dependent *)
   | _, Basetype "uint8_t", _ -> 1
   | _ -> 0 (* non‐numeric or unknown *)
 
@@ -944,12 +952,11 @@ and typecheck_expr ?(expected_return : perktype option = None) (expr : expr_a) :
   | Subscript (container, accessor) -> (
       let container_res, container_type = typecheck_expr container in
       let accessor_res, accessor_type = typecheck_expr accessor in
-      if is_integral accessor_type then
-        ()
+      if is_integral accessor_type then ()
       else
         raise_type_error expr
           (Printf.sprintf "Subscript operator requires integer type, got %s"
-            (show_perktype accessor_type))
+             (show_perktype accessor_type));
       match container_type with
       | _, Arraytype (t, _n), _ ->
           (annot_copy expr (Subscript (container_res, accessor_res)), t)


### PR DESCRIPTION
Solving #14

I hope this is all that needs to be changed to handle any integral types, 

P.S. didn't have chance to test it out properly due to ~~tiny~~ Nix mis-configuration issue on my machine c: